### PR TITLE
Fix rare bug in Resque::Plugins::WaitingRoom fail to set expiration to the perform counter

### DIFF
--- a/lib/resque/plugins/waiting_room.rb
+++ b/lib/resque/plugins/waiting_room.rb
@@ -19,6 +19,7 @@ module Resque
 
         if has_remaining_performs_key?(key)
           performs_left = Resque.redis.decrby(key, 1).to_i
+          ensure_has_expireation(key)
 
           if performs_left < 1
             Resque.push 'waiting_room', class: self.to_s, args: args
@@ -42,6 +43,10 @@ module Resque
         Resque.push 'waiting_room', class: self.to_s, args: args if no_performs_left
 
         return no_performs_left
+      end
+
+      def ensure_has_expireation(key)
+        Resque.redis.expire(key, @period) if Resque.redis.ttl(key) == -1
       end
     end
   end

--- a/spec/resque/plugins/waiting_room_spec.rb
+++ b/spec/resque/plugins/waiting_room_spec.rb
@@ -56,6 +56,12 @@ describe Resque::Plugins::WaitingRoom do
       Resque.redis.get("DummyJob:remaining_performs").should =="1"
       expect { DummyJob.before_perform_waiting_room('args') }.to raise_exception(Resque::DontPerform)
     end
+
+    it "should call ensure_has_expireation" do
+      DummyJob.before_perform_waiting_room('args')
+      DummyJob.should_receive(:ensure_has_expireation)
+      DummyJob.before_perform_waiting_room('args')
+    end
   end
 
   context "has_remaining_performs_key?" do
@@ -119,4 +125,20 @@ describe Resque::Plugins::WaitingRoom do
     end
   end
 
+  context "ensure_has_expireation" do
+    it "should set expire to the key when it doesn't have any expiration" do
+      Resque.redis.set(DummyJob.waiting_room_redis_key, 10)
+
+      DummyJob.ensure_has_expireation(DummyJob.waiting_room_redis_key)
+      Resque.redis.ttl(DummyJob.waiting_room_redis_key).should == 30
+    end
+
+    it "should not change expire when it has an expiration" do
+      Resque.redis.set(DummyJob.waiting_room_redis_key, 10)
+      Resque.redis.expire(DummyJob.waiting_room_redis_key, 15)
+
+      DummyJob.ensure_has_expireation(DummyJob.waiting_room_redis_key)
+      Resque.redis.ttl(DummyJob.waiting_room_redis_key).should == 15
+    end
+  end
 end


### PR DESCRIPTION
I found a rare bug that has happened in Resque::Plugins::WaitingRoom.

I had noticed our resque's `Example:remaining_performs` counter doesn't have any expiration once in a long while.
In the case, our resque can't perform any new job until I manually delete the `Example:remaining_performs` key.

I think it's caused by following case.

```
 [Ruby process]                      [remaining_performs key in Redis] 
-------------------------------------------------------------------------------
has_remaining_performs_key?           TTL is very small
  |                                               
  |                                   ( expired!! )
  |                                               
Resque.redis.decrby                   SET -1 and TTL is nothing
  |                                            
```

I had tried to fix this problem by using redis's `WATCH / MULTI / EXEC` commands but it hard to do.
So, I did quick fix :)
