### PR TITLE
updated has_remaining_performs_key to use set

### DIFF
--- a/lib/resque/plugins/waiting_room.rb
+++ b/lib/resque/plugins/waiting_room.rb
@@ -28,9 +28,8 @@ module Resque
       end
 
       def has_remaining_performs_key?(key)
-        # Redis SETNX: sets the keys if it doesn't exist, returns true if key was created
-        #new_key = Resque.redis.setnx(key, @max_performs - 1)
-        #Resque.redis.expire(key, @period) if new_key
+        # Redis SET: with the ex and nx option  sets the keys if it doesn't exist, 
+        # returns true if key was created redis => 2.6 required
         new_key = Resque.redis.set(key, @max_performs - 1,{ex: @period, nx: true})
         return !new_key
       end

--- a/spec/resque/plugins/job_spec.rb
+++ b/spec/resque/plugins/job_spec.rb
@@ -9,32 +9,32 @@ describe Resque::Job do
   context "normal job" do
     it "should trigger original reserve" do
       Resque.push('normal', class: 'DummyJob', args: ['any args'])
-      Resque::Job.reserve('normal').should == Resque::Job.new('normal', {'class' => 'DummyJob', 'args' => ['any args']})
-      Resque::Job.reserve('waiting_room').should be_nil
+      expect(Resque::Job.reserve('normal')).to eq(Resque::Job.new('normal', {'class' => 'DummyJob', 'args' => ['any args']}))
+      expect(Resque::Job.reserve('waiting_room')).to eq(nil)
     end
   end
 
   context "waiting_room job" do
     it "should push in the waiting_room queue when reserve from waiting_room queue" do
       Resque.push('waiting_room', class: 'DummyJob', args: ['any args'])
-      Resque::Job.reserve('waiting_room').should == Resque::Job.new('waiting_room', {'class' => 'DummyJob', 'args' => ['any args']})
-      Resque::Job.reserve('normal').should be_nil
+      expect(Resque::Job.reserve('waiting_room')).to eq(Resque::Job.new('waiting_room', {'class' => 'DummyJob', 'args' => ['any args']}))
+      expect(Resque::Job.reserve('normal')).to eq(nil)
     end
 
     it "should push back to waiting_room queue when still restricted" do
       Resque.push('waiting_room', class: 'DummyJob', args: ['any args'])
-      DummyJob.should_receive(:repush).with('any args')
-      Resque::Job.reserve('waiting_room').should == Resque::Job.new('waiting_room', {'class' => 'DummyJob', 'args' => ['any args']})
-      Resque::Job.reserve('waiting_room').should be_nil
-      Resque::Job.reserve('normal').should be_nil
+      expect(DummyJob).to receive(:repush).with('any args')
+      expect(Resque::Job.reserve('waiting_room')).to eq(Resque::Job.new('waiting_room', {'class' => 'DummyJob', 'args' => ['any args']}))
+      expect(Resque::Job.reserve('waiting_room')).to eq(nil)
+      expect(Resque::Job.reserve('normal')).to eq(nil)
     end
 
     it "should not repush when reserve normal queue" do
       Resque.push('normal', class: 'DummyJob', args: ['any args'])
-      DummyJob.should_not_receive(:repush).with('any args')
-      Resque::Job.reserve('normal').should == Resque::Job.new('normal', {'class' => 'DummyJob', 'args' => ['any args']})
-      Resque::Job.reserve('normal').should be_nil
-      Resque::Job.reserve('waiting_room').should be_nil
+      expect(DummyJob).not_to receive(:repush).with('any args')
+      expect(Resque::Job.reserve('normal')).to eq(Resque::Job.new('normal', {'class' => 'DummyJob', 'args' => ['any args']}))
+      expect(Resque::Job.reserve('normal')).to eq(nil)
+      expect(Resque::Job.reserve('waiting_room')).to eq(nil)
     end
   end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -11,13 +11,13 @@ RSpec::Matchers.define :be_only_performed do |expected_options|
     actual_job_class.instance_variable_get(:@max_performs) == expected_times].all?
   end
 
-  failure_message_for_should do |actual_job_class|
+  failure_message do |actual_job_class|
     actual_times = actual_job_class.instance_variable_get(:@max_performs)
     actual_period = actual_job_class.instance_variable_get(:@period)
     "expected #{actual_job_class} to have defined can_be_performed times: #{expected_options[:times]} period: #{expected_options[:period]}, got can_be_performed times: #{actual_times} period: #{actual_times}"
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected #{actual_job_class} to have NOT defined can_be_performed times: #{expected_options[:times]} period: #{expected_options[:period]}"
   end
 


### PR DESCRIPTION
has_remaining_performs_key was using two commands to try and establish a lock.  In production I found this to be error prone.  I changed the code to use the latest form set which will set an expiration and only set the key if it doesn't exist.  This is the preferred way to establish a lock using redis per the documentation. http://redis.io/commands/set
