### PR TITLE
feat(restriction identifier): pass arguments to redis key

### DIFF
--- a/lib/resque/plugins/waiting_room.rb
+++ b/lib/resque/plugins/waiting_room.rb
@@ -10,12 +10,12 @@ module Resque
         @max_performs ||= params[:times].to_i
       end
 
-      def waiting_room_redis_key
+      def waiting_room_redis_key(*args)
         [self.to_s, 'remaining_performs'].compact.join(':')
       end
 
       def before_perform_waiting_room(*args)
-        key = waiting_room_redis_key
+        key = waiting_room_redis_key(args)
         return unless remaining_performs_key?(key)
 
         performs_left = Resque.redis.decrby(key, 1).to_i
@@ -40,7 +40,7 @@ module Resque
       end
 
       def repush(*args)
-        key = waiting_room_redis_key
+        key = waiting_room_redis_key(args)
         value = Resque.redis.get(key)
         no_performs_left = value && value != '' && value.to_i <= 0
         Resque.push 'waiting_room', class: self.to_s, args: args if no_performs_left

--- a/lib/resque/plugins/waiting_room.rb
+++ b/lib/resque/plugins/waiting_room.rb
@@ -10,7 +10,7 @@ module Resque
         @max_performs ||= params[:times].to_i
       end
 
-      def waiting_room_redis_key(*args)
+      def waiting_room_redis_key(*_args)
         [self.to_s, 'remaining_performs'].compact.join(':')
       end
 

--- a/spec/resque/plugins/waiting_room_spec.rb
+++ b/spec/resque/plugins/waiting_room_spec.rb
@@ -26,6 +26,10 @@ describe Resque::Plugins::WaitingRoom do
       expect(DummyJob.waiting_room_redis_key)
         .to eq('DummyJob:remaining_performs')
     end
+    it 'should generate a redis key name based on the class and enable args' do
+      expect(DummyJob.waiting_room_redis_key('123', '111', '4444'))
+          .to eq('DummyJob:remaining_performs')
+    end
   end
 
   context 'custom matcher' do


### PR DESCRIPTION
I pass args to waiting_room_redis_key so the key could be determined dynamically.
The user can override waiting_room_redis_key (in the job) and use the args to determine the redis key.
It is useful for a scenario where we have a job to restrict the facebook post numbers 40 times per user per day - then the redis key could be by user id.

def self.waiting_room_redis_key(*args)
        [self.to_s, args['user_id']].compact.join(':')
end
